### PR TITLE
chore: added autoformat on save

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+    "parser": "typescript",
+    "singleQuote": true,
+    "trailingComma": "all",
+    "tabWidth": 4,
+    "printWidth": 120,
+    "useTabs": false,
+    "arrowParens": "avoid"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+    "search.exclude": {
+        "**/node_modules": true,
+        "**/dist": true,
+        "**/.vscode": true
+    },
+    "files.eol": "\n",
+    "files.trimTrailingWhitespace": true,
+    "typescript.tsdk": "./node_modules/typescript/lib",
+    "prettier.prettierPath": "./node_modules/prettier",
+    "prettier.configPath": "./.prettierrc.json",
+    "editor.formatOnSave": true,
+    "html.format.enable": false,
+    "editor.formatOnPaste": false
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -4701,6 +4701,11 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
     },
+    "prettier": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
+      "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg=="
+    },
     "pretty-error": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@typescript-eslint/eslint-plugin": "^4.6.0",
     "@typescript-eslint/parser": "^4.6.0",
     "clean-webpack-plugin": "^3.0.0",
+    "prettier": "^2.1.2",
     "eslint": "^7.12.1",
     "html-webpack-plugin": "^4.5.0",
     "ts-loader": "^8.0.7",


### PR DESCRIPTION
Added autoformat on save. 
1. Install VSCode extention Prettier
Name: Prettier - Code formatter
Id: esbenp.prettier-vscode
Description: Code formatter using prettier
Version: 5.7.1
Publisher: Prettier
VS Marketplace Link: https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode
2. Run npm ci